### PR TITLE
Allow to invoke and accept inline completions with `Tab`

### DIFF
--- a/galata/test/jupyterlab/inline-completer.test.ts
+++ b/galata/test/jupyterlab/inline-completer.test.ts
@@ -168,6 +168,8 @@ test.describe('Inline Completer', () => {
     });
 
     test('Accepts suggestion on Tab', async ({ page }) => {
+      await page.keyboard.press('u');
+
       await page.evaluate(async () => {
         await window.jupyterapp.commands.execute('inline-completer:invoke');
       });

--- a/galata/test/jupyterlab/inline-completer.test.ts
+++ b/galata/test/jupyterlab/inline-completer.test.ts
@@ -7,6 +7,7 @@ const fileName = 'notebook.ipynb';
 const COMPLETER_SELECTOR = '.jp-InlineCompleter';
 const GHOST_SELECTOR = '.jp-GhostText';
 const PLUGIN_ID = '@jupyterlab/completer-extension:inline-completer';
+const SHORTCUTS_ID = '@jupyterlab/shortcuts-extension:shortcuts';
 
 const SHARED_SETTINGS = {
   providers: {
@@ -114,6 +115,71 @@ test.describe('Inline Completer', () => {
       // Widget shows up
       const completer = page.locator(COMPLETER_SELECTOR);
       await completer.waitFor();
+    });
+  });
+
+  test.describe('Invoke on Tab', () => {
+    test.use({
+      mockSettings: {
+        ...galata.DEFAULT_SETTINGS,
+        [PLUGIN_ID]: {
+          showWidget: 'always',
+          ...SHARED_SETTINGS
+        },
+        [SHORTCUTS_ID]: {
+          shortcuts: [
+            {
+              command: 'inline-completer:invoke',
+              keys: ['Tab'],
+              selector: '.jp-mod-completer-enabled'
+            }
+          ]
+        }
+      }
+    });
+
+    test('Shows up on Tab', async ({ page }) => {
+      await page.keyboard.press('Tab');
+
+      // Widget shows up
+      const completer = page.locator(COMPLETER_SELECTOR);
+      await completer.waitFor();
+    });
+  });
+
+  test.describe('Accept on Tab', () => {
+    test.use({
+      mockSettings: {
+        ...galata.DEFAULT_SETTINGS,
+        [PLUGIN_ID]: {
+          showWidget: 'always',
+          ...SHARED_SETTINGS
+        },
+        [SHORTCUTS_ID]: {
+          shortcuts: [
+            {
+              command: 'inline-completer:accept',
+              keys: ['Tab'],
+              selector: '.jp-mod-inline-completer-active'
+            }
+          ]
+        }
+      }
+    });
+
+    test('Accepts suggestion on Tab', async ({ page }) => {
+      await page.evaluate(async () => {
+        await window.jupyterapp.commands.execute('inline-completer:invoke');
+      });
+
+      const completer = page.locator(COMPLETER_SELECTOR);
+      await completer.waitFor();
+
+      await page.keyboard.press('Tab');
+
+      const cellEditor = await page.notebook.getCellInput(2);
+      const text = await cellEditor.textContent();
+      expect(text).toMatch(/estion.*/);
     });
   });
 

--- a/packages/completer-extension/schema/inline-completer.json
+++ b/packages/completer-extension/schema/inline-completer.json
@@ -18,7 +18,7 @@
     {
       "command": "inline-completer:accept",
       "keys": ["Alt End"],
-      "selector": ".jp-mod-completer-enabled"
+      "selector": ".jp-mod-inline-completer-active"
     },
     {
       "command": "inline-completer:invoke",

--- a/packages/completer-extension/src/index.ts
+++ b/packages/completer-extension/src/index.ts
@@ -106,13 +106,35 @@ const inlineCompleterFactory: JupyterFrontEndPlugin<IInlineCompleterFactory> = {
             : '';
           return keys ? `${keys}` : '';
         };
+
+        const labelCache = {
+          [CommandIDs.previousInline]: describeShortcut(
+            CommandIDs.previousInline
+          ),
+          [CommandIDs.nextInline]: describeShortcut(CommandIDs.nextInline),
+          [CommandIDs.acceptInline]: describeShortcut(CommandIDs.acceptInline)
+        };
+
+        app.commands.keyBindingChanged.connect(
+          (
+            _emitter: CommandRegistry,
+            change: CommandRegistry.IKeyBindingChangedArgs
+          ) => {
+            const command = change.binding.command;
+            if (labelCache.hasOwnProperty(command)) {
+              labelCache[command as keyof typeof labelCache] =
+                describeShortcut(command);
+            }
+          }
+        );
+
         inlineCompleter.toolbar.addItem(
           'previous-inline-completion',
           new CommandToolbarButton({
             commands: app.commands,
             icon: caretLeftIcon,
             id: CommandIDs.previousInline,
-            label: describeShortcut(CommandIDs.previousInline),
+            label: () => labelCache[CommandIDs.previousInline],
             caption: trans.__('Previous')
           })
         );
@@ -122,7 +144,7 @@ const inlineCompleterFactory: JupyterFrontEndPlugin<IInlineCompleterFactory> = {
             commands: app.commands,
             icon: caretRightIcon,
             id: CommandIDs.nextInline,
-            label: describeShortcut(CommandIDs.nextInline),
+            label: () => labelCache[CommandIDs.nextInline],
             caption: trans.__('Next')
           })
         );
@@ -132,7 +154,7 @@ const inlineCompleterFactory: JupyterFrontEndPlugin<IInlineCompleterFactory> = {
             commands: app.commands,
             icon: checkIcon,
             id: CommandIDs.acceptInline,
-            label: describeShortcut(CommandIDs.acceptInline),
+            label: () => labelCache[CommandIDs.acceptInline],
             caption: trans.__('Accept')
           })
         );
@@ -289,6 +311,68 @@ const inlineCompleter: JupyterFrontEndPlugin<void> = {
           .catch(console.error);
       })
       .catch(console.error);
+
+    const findKeybinding = (
+      commandID: string
+    ): CommandRegistry.IKeyBinding | undefined => {
+      return app.commands.keyBindings.find(
+        binding => binding.command === commandID
+      );
+    };
+
+    const keyBindings = {
+      [CommandIDs.acceptInline]: findKeybinding(CommandIDs.acceptInline),
+      [CommandIDs.invokeInline]: findKeybinding(CommandIDs.invokeInline)
+    };
+
+    app.commands.keyBindingChanged.connect(
+      (
+        _emitter: CommandRegistry,
+        change: CommandRegistry.IKeyBindingChangedArgs
+      ) => {
+        const command = change.binding.command;
+        if (keyBindings.hasOwnProperty(command)) {
+          keyBindings[command as keyof typeof keyBindings] =
+            findKeybinding(command);
+        }
+      }
+    );
+
+    const evtKeydown = (event: KeyboardEvent) => {
+      // Handle bindings to `Tab` key specially
+      if (!(event.target instanceof Element)) {
+        return;
+      }
+      const target = event.target as Element;
+      switch (event.keyCode) {
+        case 9: {
+          // Tab key
+          const potentialTabBindings = [
+            // Note: `accept` should come ahead of `invoke` due to specificity
+            keyBindings[CommandIDs.acceptInline],
+            keyBindings[CommandIDs.invokeInline]
+          ];
+          for (const binding of potentialTabBindings) {
+            if (
+              binding &&
+              binding.keys.length === 1 &&
+              binding.keys[0] === 'Tab' &&
+              target.closest(binding.selector)
+            ) {
+              app.commands.execute(binding.command);
+              event.preventDefault();
+              event.stopPropagation();
+              event.stopImmediatePropagation();
+              return;
+            }
+          }
+          break;
+        }
+        default:
+          return;
+      }
+    };
+    document.addEventListener('keydown', evtKeydown, true);
   }
 };
 

--- a/packages/completer-extension/src/index.ts
+++ b/packages/completer-extension/src/index.ts
@@ -359,7 +359,7 @@ const inlineCompleter: JupyterFrontEndPlugin<void> = {
               binding.keys[0] === 'Tab' &&
               target.closest(binding.selector)
             ) {
-              app.commands.execute(binding.command);
+              app.commands.execute(binding.command).catch(console.error);
               event.preventDefault();
               event.stopPropagation();
               event.stopImmediatePropagation();

--- a/packages/completer/src/inline.ts
+++ b/packages/completer/src/inline.ts
@@ -20,6 +20,7 @@ import { CompletionHandler } from './handler';
 import { GhostTextManager } from './ghost';
 
 const INLINE_COMPLETER_CLASS = 'jp-InlineCompleter';
+const INLINE_COMPLETER_ACTIVE_CLASS = 'jp-mod-inline-completer-active';
 const HOVER_CLASS = 'jp-InlineCompleter-hover';
 const PROGRESS_BAR_CLASS = 'jp-InlineCompleter-progressBar';
 
@@ -310,6 +311,8 @@ export class InlineCompleter extends Widget {
       // Cancel removing ghost text if our node is receiving focus
       return false;
     }
+    // The ghost text will be removed, so nothing to accept
+    this._editor?.host.classList.remove(INLINE_COMPLETER_ACTIVE_CLASS);
     // Hide the widget if editor was blurred.
     this.hide();
   }
@@ -328,6 +331,7 @@ export class InlineCompleter extends Widget {
       const editor = this.editor;
       if (editor) {
         this._ghostManager.clearGhosts((editor as CodeMirrorEditor).editor);
+        editor.host.classList.remove(INLINE_COMPLETER_ACTIVE_CLASS);
       }
     }
     this._updateStreamTracking();
@@ -413,6 +417,7 @@ export class InlineCompleter extends Widget {
       onPointerOver: this._onPointerOverGhost.bind(this),
       onPointerLeave: this._onPointerLeaveGhost.bind(this)
     });
+    editor.host.classList.add(INLINE_COMPLETER_ACTIVE_CLASS);
   }
 
   private _onPointerOverGhost() {

--- a/packages/ui-components/src/components/toolbar.tsx
+++ b/packages/ui-components/src/components/toolbar.tsx
@@ -910,7 +910,7 @@ export namespace CommandToolbarButtonComponent {
     /**
      * Overrides command label
      */
-    label?: string;
+    label?: string | CommandRegistry.CommandFunc<string>;
     /**
      * Overrides command caption
      */
@@ -1209,9 +1209,13 @@ namespace Private {
     if (!commands.isVisible(id, args)) {
       className += ' lm-mod-hidden';
     }
+    const labelOverride =
+      typeof options.label === 'function'
+        ? options.label(args ?? {})
+        : options.label;
 
     let tooltip =
-      commands.caption(id, args) || options.label || label || iconLabel;
+      commands.caption(id, args) || labelOverride || label || iconLabel;
     // Shows hot keys in tooltips
     const binding = commands.keyBindings.find(b => b.command === id);
     if (binding) {
@@ -1231,7 +1235,7 @@ namespace Private {
       tooltip: options.caption ?? tooltip,
       onClick,
       enabled,
-      label: options.label ?? label,
+      label: labelOverride ?? label,
       pressed
     };
   }


### PR DESCRIPTION
## References

- fixes 15549
- follow up to 15160

## Code changes

- add event listener to intercept the <kbd>Tab</kbd> press and if needed dispatch appropriate action
  - correct the selector for command accepting of inline completion so that it is only active when there is a suggestion (by adding `jp-mod-inline-completer-active` class) - this is required to allow configuring both `invoke` and `accept` actions to respond to <kbd>Tab</kbd>
- make shortcut labels on the inline completer widget reflect the current shortcut rather than initial one
  - change `CommandToolbarButtonComponent` to accept `label` function, matching the commands API

## User-facing changes

-  <kbd>Tab</kbd>  works for `accept` and `invoke` of inline completer
- It is now possible to set both `accept` and `invoke` to  <kbd>Tab</kbd> 
   ![image](https://github.com/krassowski/jupyterlab/assets/5832902/d05320ef-171f-4962-af5b-16bd56609641)
- The shortcuts now appear reliably in the inline completer widget; previously these were randomly missing despite being enabled
- The shortcuts in the inline completer widget now reflect the current shortcut without need to reload JupyterLab
  ![image](https://github.com/krassowski/jupyterlab/assets/5832902/84c9b209-0b3b-40dc-aa5f-028660bbcd27)


## Backwards-incompatible changes

None