### PR TITLE
Preserve shortcut metadata when editing keybindings

### DIFF
--- a/packages/shortcuts-extension/src/components/ShortcutInput.tsx
+++ b/packages/shortcuts-extension/src/components/ShortcutInput.tsx
@@ -6,6 +6,7 @@
 
 import * as React from 'react';
 import type { ITranslator } from '@jupyterlab/translation';
+import { CommandRegistry } from '@lumino/commands';
 import { JSONExt } from '@lumino/coreutils';
 import { EN_US } from '@lumino/keyboard';
 import { checkIcon, errorIcon } from '@jupyterlab/ui-components';
@@ -129,11 +130,12 @@ export class ShortcutInput extends React.Component<
     conflicts: IShortcutTarget[],
     keys: string[]
   ) => {
+    const normalizedKeys = keys.map(CommandRegistry.normalizeKeystroke);
     for (const conflict of conflicts) {
       const conflictingBinding = conflict.keybindings.filter(
         binding =>
-          JSONExt.deepEqual(binding.keys, keys) ||
-          keys.some(key => JSONExt.deepEqual(binding.keys, [key]))
+          JSONExt.deepEqual(binding.keys, normalizedKeys) ||
+          normalizedKeys.some(key => JSONExt.deepEqual(binding.keys, [key]))
       )[0];
       if (!conflictingBinding) {
         console.error(

--- a/packages/shortcuts-extension/src/components/ShortcutItem.tsx
+++ b/packages/shortcuts-extension/src/components/ShortcutItem.tsx
@@ -29,7 +29,8 @@ const MAC_SYMBOLS: Record<string, string> = {
   Ctrl: '⌃',
   Alt: '⌥',
   Shift: '⇧',
-  Accel: '⌘'
+  Accel: '⌘',
+  Cmd: '⌘'
 };
 
 /** Props for ShortcutItem component */

--- a/packages/shortcuts-extension/src/components/ShortcutUI.tsx
+++ b/packages/shortcuts-extension/src/components/ShortcutUI.tsx
@@ -8,6 +8,7 @@ import type { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { CommandRegistry } from '@lumino/commands';
 import type { ReadonlyJSONObject } from '@lumino/coreutils';
 import { JSONExt } from '@lumino/coreutils';
+import { Platform } from '@lumino/domutils';
 import * as React from 'react';
 import { NewShortcutItem } from './NewShortcutItem';
 import { ShortcutItem } from './ShortcutItem';
@@ -23,6 +24,10 @@ import type {
   IShortcutTarget,
   IShortcutUI
 } from '../types';
+
+type ShortcutOverride = CommandRegistry.IKeyBindingOptions & {
+  disabled?: boolean;
+};
 
 /** Props for ShortcutUI component */
 export interface IShortcutUIProps {
@@ -251,11 +256,7 @@ export class ShortcutUI
         // Also, if the keybinding is a default keybinding and the desired
         // new `keys` are the same as default, it does not need to be added.
         if (keys.length !== 0 && !matchesDefault) {
-          newUserShortcuts.push({
-            command: shortcut.command,
-            selector: shortcut.selector,
-            keys: keys
-          });
+          newUserShortcuts.push(this._setShortcutKeys(shortcut, keys));
         }
         found = true;
       } else if (
@@ -277,23 +278,71 @@ export class ShortcutUI
         keybinding && keybinding.isDefault && requiresChange;
       if (shouldDisableDefault) {
         // If the replaced keybinding is the default, disable it.
-        newUserShortcuts.push({
-          command: target.command,
-          selector: target.selector,
-          disabled: true,
-          keys: keybinding.keys
-        });
+        newUserShortcuts.push(
+          this._shortcutFromTarget(target, keybinding.keys, {
+            disabled: true,
+            preventDefault: keybinding.preventDefault
+          })
+        );
       }
       if (keys.length !== 0) {
-        newUserShortcuts.push({
-          command: target.command,
-          selector: target.selector,
-          keys: keys
-        });
+        newUserShortcuts.push(
+          this._shortcutFromTarget(target, keys, {
+            preventDefault: keybinding?.preventDefault
+          })
+        );
       }
     }
     await settings.set('shortcuts', newUserShortcuts as any);
     await this._refreshShortcutList();
+  }
+
+  private _setShortcutKeys(
+    shortcut: CommandRegistry.IKeyBindingOptions,
+    keys: string[]
+  ): CommandRegistry.IKeyBindingOptions {
+    const keyField = this._platformKeys(shortcut);
+    return {
+      ...shortcut,
+      [keyField]: keys
+    };
+  }
+
+  private _shortcutFromTarget(
+    target: IShortcutTarget,
+    keys: string[],
+    options: { disabled?: boolean; preventDefault?: boolean } = {}
+  ): ShortcutOverride {
+    const shortcut: ShortcutOverride = {
+      command: target.command,
+      selector: target.selector,
+      keys
+    };
+    if (target.args && !JSONExt.deepEqual(target.args, {})) {
+      shortcut.args = target.args;
+    }
+    if (options.disabled) {
+      shortcut.disabled = true;
+    }
+    if (options.preventDefault !== undefined) {
+      shortcut.preventDefault = options.preventDefault;
+    }
+    return shortcut;
+  }
+
+  private _platformKeys(
+    shortcut: CommandRegistry.IKeyBindingOptions
+  ): 'keys' | 'winKeys' | 'macKeys' | 'linuxKeys' {
+    if (Platform.IS_WIN && shortcut.winKeys) {
+      return 'winKeys';
+    }
+    if (Platform.IS_MAC && shortcut.macKeys) {
+      return 'macKeys';
+    }
+    if (!Platform.IS_WIN && !Platform.IS_MAC && shortcut.linuxKeys) {
+      return 'linuxKeys';
+    }
+    return 'keys';
   }
 
   /**

--- a/packages/shortcuts-extension/src/registry.ts
+++ b/packages/shortcuts-extension/src/registry.ts
@@ -75,7 +75,10 @@ export class ShortcutRegistry
         const keybinding: IKeybinding = {
           // Resolve platform-specific keys (`winKeys`/`linuxKeys`/`macKeys` with fallback to `keys`)
           keys: CommandRegistry.normalizeKeys(shortcut),
-          isDefault: !setByUser.has(keybindingKey)
+          isDefault: !setByUser.has(keybindingKey),
+          ...(shortcut.preventDefault === undefined
+            ? {}
+            : { preventDefault: shortcut.preventDefault })
         };
 
         const shortcutTarget = this.get(targetKey);
@@ -107,16 +110,17 @@ export class ShortcutRegistry
    */
   findConflictsFor(keys: string[], selector: string): IShortcutTarget[] {
     const checker = new KeybindingsConflictChecker({ registry: this });
+    const normalizedKeys = keys.map(CommandRegistry.normalizeKeystroke);
 
     // First check the full chain
-    let conflicts = checker.findConflicts(keys, selector);
+    let conflicts = checker.findConflicts(normalizedKeys, selector);
 
     if (conflicts.length !== 0) {
       return conflicts;
     }
 
     // Then check each piece of the chain
-    for (const binding of keys) {
+    for (const binding of normalizedKeys) {
       conflicts = checker.findConflicts([binding], selector);
       if (conflicts.length !== 0) {
         return conflicts;

--- a/packages/shortcuts-extension/src/types.ts
+++ b/packages/shortcuts-extension/src/types.ts
@@ -48,6 +48,10 @@ export interface IKeybinding {
    * Whether this keybinding comes from default values (schema or default overrides), or is set by user.
    */
   readonly isDefault: boolean;
+  /**
+   * Whether to prevent default action of the keyboard events during sequence matching.
+   */
+  readonly preventDefault?: boolean;
 }
 
 /**

--- a/packages/shortcuts-extension/test/components/ShortcutUI.spec.ts
+++ b/packages/shortcuts-extension/test/components/ShortcutUI.spec.ts
@@ -10,6 +10,7 @@ import type {
 import { CommandRegistry } from '@lumino/commands';
 import type { JSONValue } from '@lumino/coreutils';
 import { PromiseDelegate } from '@lumino/coreutils';
+import { Platform } from '@lumino/domutils';
 import { Signal } from '@lumino/signaling';
 import type { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { SettingRegistry, Settings } from '@jupyterlab/settingregistry';
@@ -129,6 +130,25 @@ describe('@jupyterlab/shortcut-extension', () => {
           selector: 'body'
         });
       });
+
+      it('should add a keybinding for given target with args', async () => {
+        const target = {
+          id: 'test-id',
+          command: 'test:command',
+          keybindings: [],
+          args: { option: 1 },
+          selector: 'body',
+          category: 'test'
+        };
+        await shortcutUI.addKeybinding(target, ['Ctrl A', 'C']);
+        expect(data.user.shortcuts).toHaveLength(1);
+        expect(data.user.shortcuts[0]).toEqual({
+          command: 'test:command',
+          keys: ['Ctrl A', 'C'],
+          selector: 'body',
+          args: { option: 1 }
+        });
+      });
     });
 
     describe('#replaceKeybinding()', () => {
@@ -222,6 +242,40 @@ describe('@jupyterlab/shortcut-extension', () => {
         });
       });
 
+      it('should preserve target args and preventDefault when replacing a default keybinding', async () => {
+        const keybinding = {
+          keys: ['Ctrl A'],
+          isDefault: true,
+          preventDefault: false
+        };
+        const target = {
+          id: 'test-id',
+          command: 'test:command',
+          keybindings: [keybinding],
+          args: { option: 1 },
+          selector: 'body',
+          category: 'test'
+        };
+        registerKeybinding(target, keybinding);
+        await shortcutUI.replaceKeybinding(target, keybinding, ['Ctrl X']);
+        expect(data.user.shortcuts).toHaveLength(2);
+        expect(data.user.shortcuts[0]).toEqual({
+          command: 'test:command',
+          keys: ['Ctrl A'],
+          selector: 'body',
+          args: { option: 1 },
+          disabled: true,
+          preventDefault: false
+        });
+        expect(data.user.shortcuts[1]).toEqual({
+          command: 'test:command',
+          keys: ['Ctrl X'],
+          selector: 'body',
+          args: { option: 1 },
+          preventDefault: false
+        });
+      });
+
       it('should replace a user keybinding whose active keys differ from fallback keys', async () => {
         // The stored `keys` are the cross-platform fallback; the resolved
         // platform keys (what the registry exposes and the UI edits) differ.
@@ -233,7 +287,9 @@ describe('@jupyterlab/shortcut-extension', () => {
           winKeys: ['Ctrl Alt Y'],
           linuxKeys: ['Ctrl Alt Y'],
           macKeys: ['Ctrl Alt Y'],
-          selector: 'body'
+          selector: 'body',
+          args: { option: 1 },
+          preventDefault: false
         } as CommandRegistry.IKeyBindingOptions);
         const keybinding = {
           keys: CommandRegistry.normalizeKeys({
@@ -248,14 +304,33 @@ describe('@jupyterlab/shortcut-extension', () => {
           id: 'test-id',
           command: 'test:command',
           keybindings: [keybinding],
-          args: {},
+          args: { option: 1 },
           selector: 'body',
           category: 'test'
         };
         await shortcutUI.replaceKeybinding(target, keybinding, ['Ctrl X']);
         // The existing user shortcut should be updated in place, not duplicated.
         expect(data.user.shortcuts).toHaveLength(1);
-        expect(data.user.shortcuts[0].keys).toEqual(['Ctrl X']);
+        const shortcut = data.user.shortcuts[0];
+        expect(CommandRegistry.normalizeKeys(shortcut)).toEqual(['Ctrl X']);
+        expect(shortcut.args).toEqual({ option: 1 });
+        expect(shortcut.preventDefault).toBe(false);
+        if (Platform.IS_WIN) {
+          expect(shortcut.winKeys).toEqual(['Ctrl X']);
+          expect(shortcut.linuxKeys).toEqual(['Ctrl Alt Y']);
+          expect(shortcut.macKeys).toEqual(['Ctrl Alt Y']);
+          expect(shortcut.keys).toEqual(['Accel Shift J']);
+        } else if (Platform.IS_MAC) {
+          expect(shortcut.macKeys).toEqual(['Ctrl X']);
+          expect(shortcut.winKeys).toEqual(['Ctrl Alt Y']);
+          expect(shortcut.linuxKeys).toEqual(['Ctrl Alt Y']);
+          expect(shortcut.keys).toEqual(['Accel Shift J']);
+        } else {
+          expect(shortcut.linuxKeys).toEqual(['Ctrl X']);
+          expect(shortcut.winKeys).toEqual(['Ctrl Alt Y']);
+          expect(shortcut.macKeys).toEqual(['Ctrl Alt Y']);
+          expect(shortcut.keys).toEqual(['Accel Shift J']);
+        }
       });
     });
 

--- a/packages/shortcuts-extension/test/registry.spec.ts
+++ b/packages/shortcuts-extension/test/registry.spec.ts
@@ -145,6 +145,18 @@ describe('@jupyterlab/shortcut-extension', () => {
         const target = [...shortcutRegistry.values()][0];
         expect(target.keybindings[0].isDefault).toBe(true);
       });
+
+      it('should preserve preventDefault on keybindings', () => {
+        data.composite.shortcuts.push({
+          command: 'test:command',
+          keys: ['Ctrl W'],
+          selector: 'body',
+          preventDefault: false
+        });
+        const shortcutRegistry = new ShortcutRegistry(options);
+        const target = [...shortcutRegistry.values()][0];
+        expect(target.keybindings[0].preventDefault).toBe(false);
+      });
     });
 
     describe('#findConflictsFor()', () => {
@@ -166,6 +178,20 @@ describe('@jupyterlab/shortcut-extension', () => {
         expect(conflicts).toHaveLength(1);
       });
 
+      it('should normalize keys before checking conflicts', () => {
+        data.composite.shortcuts.push({
+          command: 'test:command',
+          keys: ['Accel S'],
+          selector: 'body'
+        });
+        const shortcutRegistry = new ShortcutRegistry(options);
+        const conflicts = shortcutRegistry.findConflictsFor(
+          ['Accel S'],
+          'body'
+        );
+        expect(conflicts).toHaveLength(1);
+      });
+
       it('should return conflicts for individual chords', () => {
         data.composite.shortcuts.push({
           command: 'test:command',
@@ -174,6 +200,20 @@ describe('@jupyterlab/shortcut-extension', () => {
         });
         const shortcutRegistry = new ShortcutRegistry(options);
         const conflicts = shortcutRegistry.findConflictsFor(['X', 'X'], 'body');
+        expect(conflicts).toHaveLength(1);
+      });
+
+      it('should normalize keys before checking individual chords', () => {
+        data.composite.shortcuts.push({
+          command: 'test:command',
+          keys: ['Accel S'],
+          selector: 'body'
+        });
+        const shortcutRegistry = new ShortcutRegistry(options);
+        const conflicts = shortcutRegistry.findConflictsFor(
+          ['Accel K', 'Accel S'],
+          'body'
+        );
         expect(conflicts).toHaveLength(1);
       });
 


### PR DESCRIPTION
## References
refs: https://github.com/jupyterlab/jupyterlab/pull/19112#issuecomment-4915598684

## Code changes

This fixes remaining shortcut UI edge cases on top of #19112 by normalizing incoming shortcut keys during conflict checks, displaying normalized Cmd shortcuts correctly on macOS, and preserving shortcut metadata such as args, platform-specific key fields, and preventDefault when editing or replacing keybindings. This prevents edited shortcuts from losing command arguments or changing behavior while keeping platform-specific bindings aligned with the active OS.

## User-facing changes
The shortcuts UI now warns about conflicts correctly for normalized/platform-specific keys, displays Cmd as ⌘ on macOS, and preserves shortcut metadata when editing keybindings.

## Backwards-incompatible changes
None

## AI usage

Yes - ChatGPT 5.5
